### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -29,7 +29,7 @@ Not sure which uploader is best for you? Read
 :::warning
 
 This plugin is deprecated, you should switch to using the
-[modern version of this plugin](./aws-s3-multipart).
+[modern version of this plugin](/docs/aws-s3-multipart).
 
 :::
 


### PR DESCRIPTION
The link to the multipart version is broken on https://uppy.io/docs/aws-s3/

This fixes that